### PR TITLE
Fixed golang version and localhost issue with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest AS builder
+FROM golang:1.13 AS builder
 WORKDIR /mafiosi
 ADD . .
 

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	host := flag.String("host", "localhost:8080", "server's host:port")
+	host := flag.String("host", ":8080", "server's host:port")
 	flag.Parse()
 
 	fmt.Println("Mafiosi server run...")


### PR DESCRIPTION
1) The command "FROM golang:latest" downloads golang version 1.11 and I was unable to build the project because it requires 1.13 version.
2) Hardcoded localhost prevents any other connections including docker ip address that is not localhost. So we were unable to connect to the server while it was running in docker container. Details: https://stackoverflow.com/questions/54101508/how-do-you-dockerize-a-websocket-server